### PR TITLE
Docs cleanup

### DIFF
--- a/docs/Basic Usage.ipynb
+++ b/docs/Basic Usage.ipynb
@@ -21,7 +21,7 @@
    "outputs": [],
    "source": [
     "# Uncomment the following line when running on Google Colab\n",
-    "# !pip install autora"
+    "# !pip install autora[theorist-bsr]"
    ]
   },
   {

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -7,7 +7,7 @@ Bayesian Symbolic Regression (BSR) has the following features:
     - Leaf nodes (M): this assigns features to leaf nodes that are already defined from part **T**.
     - Operator parameters ($\Theta$): this uses a vector $\Theta$ to collect additional parameters for certain operators which require them (e.g. a linear operator `ln` with intercept and slope params).
 
-2. It specifies priors for each of the three parts above. `Autora`'s implementation of BSR allows users to either specify custom priors for part `T` or choose among a pre-specified set.
+2. It specifies priors for each of the three parts above. `AutoRA`'s implementation of BSR allows users to either specify custom priors for part `T` or choose among a pre-specified set.
 
 3. It defines `actions` that mutate one expression tree (`original`) into a new expression tree (`proposed`), and supports the calculation of transition probabilities based on the likelihoods of the `original` and `proposed` models.
 

--- a/docs/meta-parameters.md
+++ b/docs/meta-parameters.md
@@ -1,6 +1,6 @@
 # Meta-Parameters
 
-Meta-Parameters are used to control the search space and the model configuration. In BSR, they are mainly defined in the theorist constructor (see `bsr.py`). Below is a basic overview of these parameters. Note, there are additional algorithm-irrelevant configurations that can be customized in the constructor; please refer to code documentation for their details.
+Meta-Parameters are used to control the search space and the model configuration. In BSR, they are mainly defined in the theorist constructor (see `regressor.py`). Below is a basic overview of these parameters. Note, there are additional algorithm-irrelevant configurations that can be customized in the constructor; please refer to code documentation for their details.
 
 - `tree_num`: the number of expression trees to use in the linear mixture (final prediction model); also denoted by `K` in BSR.
 - `iter_num`: the number of RJ-MCMC steps to execute (note: this can also be understood as the number of `K`-samples to take in the fitting process).


### PR DESCRIPTION
quick fixes:

- reference to renamed file
- installation of new namespace subpackage
- case consistency of AutoRA