### PR TITLE
chore: debug types and change random number generators

### DIFF
--- a/src/autora/theorist/bsr/node.py
+++ b/src/autora/theorist/bsr/node.py
@@ -48,7 +48,7 @@ class Node:
         self.op_init = op_init
 
         # holding temporary calculation result, see `evaluate()`
-        self.result = None
+        self.result: Optional[np.ndarray] = None
         # params for additional inputs into `operator`
         self.params: Dict = {}
 
@@ -98,7 +98,7 @@ class Node:
 
     def evaluate(
         self, X: Union[np.ndarray, pd.DataFrame], store_result: bool = False
-    ) -> np.array:
+    ) -> np.ndarray:
         """
         Evaluate the expression, as represented by an expression tree with `self` as the root,
         using the given data matrix `X`.

--- a/src/autora/theorist/bsr/operation.py
+++ b/src/autora/theorist/bsr/operation.py
@@ -6,7 +6,7 @@ import numpy as np
 this file contains functions (operators) for actually carrying out the computations
 in our expression tree model. An operator can take in either 1 (unary) or 2 (binary)
 operands - corresponding to being used in a unary or binary node (see `node.py`). The
-operand(s) are recursively evaluated `np.array` from an operation or literal (in the
+operand(s) are recursively evaluated `np.ndarray` from an operation or literal (in the
 case of a leaf node) in downstream node(s).
 
 For certain operator, e.g. a linear operator, auxiliary parameters (slope/intercept)
@@ -16,38 +16,38 @@ initialized in `prior.py` by their specified initialization functions.
 
 
 # a linear operator with default `a` = 1 and `b` = 0 (i.e. identity operation)
-def linear_op(operand: np.array, **params: Dict) -> np.array:
-    a, b = params.get("a", 1), params.get("b", 0)
+def linear_op(operand: np.ndarray, **params: Dict[str, float]) -> np.ndarray:
+    a, b = params.get("a", 1.0), params.get("b", 0.0)
     return a * operand + b
 
 
 # a safe `exp` operation that has a cutoff (default = 1e-10) and avoids overflow
-def exp_op(operand: np.array, **params: Dict) -> np.array:
+def exp_op(operand: np.ndarray, **params: Dict[str, float]) -> np.ndarray:
     cutoff = params.get("cutoff", 1e-10)
     return 1 / (cutoff + np.exp(-operand))
 
 
 # a safe `inv` operation that has a cutoff (default = 1e-10) and avoids overflow
-def inv_op(operand: np.array, **params: Dict) -> np.array:
+def inv_op(operand: np.ndarray, **params: Dict[str, float]) -> np.ndarray:
     cutoff = params.get("cutoff", 1e-10)
     return 1 / (cutoff + operand)
 
 
-def neg_op(operand: np.array) -> np.array:
+def neg_op(operand: np.ndarray) -> np.ndarray:
     return -operand
 
 
-def sin_op(operand: np.array) -> np.array:
+def sin_op(operand: np.ndarray) -> np.ndarray:
     return np.sin(operand)
 
 
-def cos_op(operand: np.array) -> np.array:
+def cos_op(operand: np.ndarray) -> np.ndarray:
     return np.cos(operand)
 
 
 # high-level func that produces power funcs such as `square`, `cubic`, etc.
-def make_pow_op(power: int) -> Callable[[np.array], np.array]:
-    def pow_op(operand: np.array) -> np.array:
+def make_pow_op(power: int) -> Callable[[np.ndarray], np.ndarray]:
+    def pow_op(operand: np.ndarray) -> np.ndarray:
         return np.power(operand, power)
 
     return pow_op
@@ -58,13 +58,13 @@ a list of binary operators
 """
 
 
-def plus_op(operand_a: np.array, operand_b: np.array):
+def plus_op(operand_a: np.ndarray, operand_b: np.ndarray):
     return operand_a + operand_b
 
 
-def minus_op(operand_a: np.array, operand_b: np.array):
+def minus_op(operand_a: np.ndarray, operand_b: np.ndarray):
     return operand_a - operand_b
 
 
-def multiply_op(operand_a: np.array, operand_b: np.array):
+def multiply_op(operand_a: np.ndarray, operand_b: np.ndarray):
     return operand_a * operand_b

--- a/src/autora/theorist/bsr/regressor.py
+++ b/src/autora/theorist/bsr/regressor.py
@@ -132,7 +132,7 @@ class BSRRegressor(BaseEstimator, RegressorMixin):
             X = pd.DataFrame(X)
         train_errs: List[List[float]] = []
         roots: List[List[Node]] = []
-        betas: List[List[float]] = []
+        betas: List[np.ndarray] = []
         itr_num = self.itr_num
         k = self.tree_num
         beta = self.beta

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+import random
+
+@pytest.fixture(autouse=True, scope='session')
+def set_seed():
+    """
+    Note that in BSR we use random functions from the random module instead of np.random
+    """
+    random.seed(2023)


### PR DESCRIPTION
This PR aims at fixing three types of errors occurred in the `mypy` output in this [job](https://github.com/AutoResearch/autora-theorist-bsr/actions/runs/6189313660/job/16803148549).

1. Incompatible typing for operation overload
> src/autora/theorist/bsr/operation.py:21: error: No overload variant of "__add__" of "ndarray" matches argument type "Dict[Any, Any]"  [operator]

This is due to the signature of the variable being simply `Dict`, and has been fixed by using `Dict[str, float]`

2. Casting between Python in-built int type and "scalar" numpy array (i.e. `np.ndarray` of size 1).
> src/autora/theorist/bsr/funcs.py:391: error: No overload variant matches argument types "List[str]", "int", "List[float]"  [call-overload]

This has been totally eliminated and refactored by using Python's in-built `random` module instead of `np.random`. Experiments have been done to show speed advantage as well.

3. Other trivial issues such as initializing a variable to be `None` in `__init__` without specifying its typing etc.

---

**p.s.** Due to the random number generator switched to be Python's in-built module, I've included a `conftest.py` file in the `tests` folder, which includes a fixture function that sets a manual seed appropriately. All three other tests in the folder will be affected under this seed.